### PR TITLE
Deploy: Vercel config + smoke

### DIFF
--- a/.github/workflows/uptime-health.yml
+++ b/.github/workflows/uptime-health.yml
@@ -1,0 +1,37 @@
+name: uptime-health
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve health URL
+        id: vars
+        run: |
+          # Prefer repo secret, else Actions variable
+          if [ -n "${{ secrets.HEALTH_URL }}" ]; then
+            echo "url=${{ secrets.HEALTH_URL }}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ vars.HEALTH_URL }}" ]; then
+            echo "url=${{ vars.HEALTH_URL }}" >> $GITHUB_OUTPUT
+          else
+            echo "::error::HEALTH_URL not set (use repo secret or Actions variable)" && exit 1
+          fi
+      - name: Curl /api/health
+        env:
+          URL: ${{ steps.vars.outputs.url }}
+        run: |
+          echo "Pinging: $URL"
+          for i in 1 2 3; do
+            code=$(curl -s -o /tmp/health.json -w "%{http_code}" "$URL") || true
+            echo "HTTP $code"
+            cat /tmp/health.json || true
+            if [ "$code" = "200" ] && jq -e '.ok == true' </tmp/health.json >/dev/null 2>&1; then
+              echo "Health OK"; exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Health check failed" && exit 1

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,26 @@
+name: vercel-preview
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci || npm install
+      - name: Build
+        env:
+          # Dummy envs for build-time expectation only; runtime secrets are set in Vercel
+          NEXTAUTH_URL: http://localhost:3000
+          NEXTAUTH_SECRET: dev
+          DATABASE_URL: postgresql://user:pass@localhost:5432/erp?schema=public
+        run: npm run build

--- a/.github/workflows/vercel-redeploy-and-probe.yml
+++ b/.github/workflows/vercel-redeploy-and-probe.yml
@@ -1,0 +1,51 @@
+name: vercel-redeploy-and-probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to comment on
+        required: true
+        default: '3'
+      base_url:
+        description: Production base URL (e.g., https://your-app.vercel.app)
+        required: true
+
+jobs:
+  redeploy-and-probe:
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.inputs.pr_number }}
+      BASE_URL: ${{ github.event.inputs.base_url }}
+      DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+    steps:
+      - name: Trigger Vercel deploy (optional)
+        run: |
+          if [ -n "$DEPLOY_HOOK" ]; then
+            echo "Triggering deploy via hook"
+            curl -sS -X POST "$DEPLOY_HOOK" || true
+            echo "Waiting for deploy to settle..."
+            sleep 30
+          else
+            echo "No VERCEL_DEPLOY_HOOK set; skipping redeploy"
+          fi
+      - name: Probe health and ERP routes
+        run: |
+          set +e
+          curl -sS "$BASE_URL/api/health" | sed -n '1,60p' > health.txt
+          curl -sS "$BASE_URL/api/customers?limit_page_length=1" | sed -n '1,60p' > customers.txt
+          curl -sS "$BASE_URL/api/sales-orders?limit_page_length=1" | sed -n '1,60p' > sales_orders.txt
+          curl -sS "$BASE_URL/api/purchase-invoices?limit_page_length=1" | sed -n '1,60p' > purchase_invoices.txt
+      - name: Comment results to PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          h=$(sed -n '1,60p' health.txt | sed 's/`/\`/g')
+          c=$(sed -n '1,60p' customers.txt | sed 's/`/\`/g')
+          s=$(sed -n '1,60p' sales_orders.txt | sed 's/`/\`/g')
+          p=$(sed -n '1,60p' purchase_invoices.txt | sed 's/`/\`/g')
+          body=$(printf "Deploy probe results (base: %s)\n\n- Health /api/health:\n\`\`\`\n%s\n\`\`\`\n\n- Customers:\n\`\`\`\n%s\n\`\`\`\n\n- Sales Orders:\n\`\`\`\n%s\n\`\`\`\n\n- Purchase Invoices:\n\`\`\`\n%s\n\`\`\`\n" "$BASE_URL" "$h" "$c" "$s" "$p")
+          jq -n --arg body "$body" '{body:$body}' > /tmp/comment.json
+          curl -s -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -d @/tmp/comment.json >/dev/null

--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ Vercel Deploy
 - Build/Run: Next.js defaults (`npm run build` / `npm start`).
 - See `vercel.json` for mapping to Vercel env secrets.
 
+CI
+
+- PR build: `.github/workflows/vercel-preview.yml` builds Next.js on pull requests to main (no secrets required) to catch regressions.
+- Uptime: optional `.github/workflows/uptime-health.yml` pings your deployed health endpoint on a schedule. Configure repository Secret or Actions Variable `HEALTH_URL` to `https://<your-app>.vercel.app/api/health`.
+
 Health & Smoke Tests
 
 - Health: `GET /api/health` → `{ "ok": true }`
 - ERPNext (read-only): see `docs/deploy-smoke.md` for curl examples.
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+ERPv3 — MVP ERP UI + ERPNext Integration
+
+Overview
+
+- Next.js 14 + Prisma (Postgres) with minimal ERP UI pages and secure ERPNext proxy routes.
+- Auth via NextAuth (credentials, httpOnly JWT cookies).
+
+Local Dev (Postgres)
+
+- Set `.env`:
+  - `DATABASE_URL=postgresql://<user>:<pass>@<host>/<db>?schema=public`
+  - `NEXTAUTH_URL=http://localhost:3000`
+  - `NEXTAUTH_SECRET=<random>`
+  - Optional: `AUTH_USER`, `AUTH_PASS` (defaults to admin/admin)
+  - Optional: `NEXTERP_HOST`, `NEXTERP_API_KEY`, `NEXTERP_API_SECRET`
+- Commands:
+  - `npm install`
+  - `npx prisma migrate dev --name init && npx prisma generate`
+  - `npm run dev` → http://localhost:3000
+
+Vercel Deploy
+
+- Connect the repo in Vercel. Set Environment Variables (Production/Preview):
+  - `DATABASE_URL` → Neon Postgres URL
+  - `NEXTAUTH_URL` → e.g., https://your-app.vercel.app
+  - `NEXTAUTH_SECRET` → long random string
+  - `NEXTERP_HOST` → e.g., napkin.v.frappe.cloud
+  - `NEXTERP_API_KEY` → ERPNext API key
+  - `NEXTERP_API_SECRET` → ERPNext API secret
+- Build/Run: Next.js defaults (`npm run build` / `npm start`).
+- See `vercel.json` for mapping to Vercel env secrets.
+
+Health & Smoke Tests
+
+- Health: `GET /api/health` → `{ "ok": true }`
+- ERPNext (read-only): see `docs/deploy-smoke.md` for curl examples.
+

--- a/README.md
+++ b/README.md
@@ -21,14 +21,32 @@ Local Dev (Postgres)
 Vercel Deploy
 
 - Connect the repo in Vercel. Set Environment Variables (Production/Preview):
-  - `DATABASE_URL` → Neon Postgres URL
+  - `DATABASE_URL` → Neon Postgres URL (recommended as Vercel Secret named `database_url`)
   - `NEXTAUTH_URL` → e.g., https://your-app.vercel.app
-  - `NEXTAUTH_SECRET` → long random string
-  - `NEXTERP_HOST` → e.g., napkin.v.frappe.cloud
-  - `NEXTERP_API_KEY` → ERPNext API key
-  - `NEXTERP_API_SECRET` → ERPNext API secret
+  - `NEXTAUTH_SECRET` → long random string (secret `nextauth_secret`)
+  - `NEXTERP_HOST` → e.g., napkin.v.frappe.cloud (secret `nexterp_host`)
+  - `NEXTERP_API_KEY` → ERPNext API key (secret `nexterp_api_key`)
+  - `NEXTERP_API_SECRET` → ERPNext API secret (secret `nexterp_api_secret`)
+  - `UPLOAD_DIR` → e.g., `./uploads` (secret `upload_dir` or plain env)
+  - `MAX_FILE_SIZE` → e.g., `1572864` (secret `max_file_size` or plain env)
 - Build/Run: Next.js defaults (`npm run build` / `npm start`).
 - See `vercel.json` for mapping to Vercel env secrets.
+
+Vercel Secrets (Option A)
+
+- Create Vercel Secrets (CLI examples):
+  - `vercel secrets add database_url postgresql://user:pass@host/db?schema=public`
+  - `vercel secrets add nextauth_secret <random>`
+  - `vercel secrets add nexterp_host napkin.v.frappe.cloud`
+  - `vercel secrets add nexterp_api_key <key>`
+  - `vercel secrets add nexterp_api_secret <secret>`
+  - `vercel secrets add upload_dir ./uploads`
+  - `vercel secrets add max_file_size 1572864`
+- vercel.json maps these via `@secret_name`.
+
+Vercel Env (Option B)
+
+- Alternatively, set the variables directly in the Project’s Environment Variables UI using the exact names (`DATABASE_URL`, `NEXTAUTH_*`, `NEXTERP_*`, `UPLOAD_DIR`, `MAX_FILE_SIZE`).
 
 CI
 

--- a/docs/deploy-smoke.md
+++ b/docs/deploy-smoke.md
@@ -1,0 +1,19 @@
+Vercel Deployment Smoke Tests
+
+Use these curl checks against your Vercel deployment (replace the base URL). ERPNext routes require server envs NEXTERP_HOST/NEXTERP_API_KEY/NEXTERP_API_SECRET. If missing or unreachable, expect a 503 JSON error.
+
+Health
+
+curl -sS https://<your-app>.vercel.app/api/health | jq .
+
+ERPNext Probes (read-only)
+
+curl -sS "https://<your-app>.vercel.app/api/customers?limit_page_length=1" | head -n 20
+curl -sS "https://<your-app>.vercel.app/api/sales-orders?limit_page_length=1" | head -n 20
+curl -sS "https://<your-app>.vercel.app/api/purchase-invoices?limit_page_length=1" | head -n 20
+
+Expected
+
+- With valid ERPNext envs and network access: JSON payloads from ERPNext.
+- Without ERPNext envs or if network blocked: `{ "error": "nexterp_credentials_missing" }` or `{ "error": "nexterp_unreachable" }`.
+

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}
+

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,9 @@
     "NEXTAUTH_URL": "@nextauth_url",
     "NEXTERP_HOST": "@nexterp_host",
     "NEXTERP_API_KEY": "@nexterp_api_key",
-    "NEXTERP_API_SECRET": "@nexterp_api_secret"
+    "NEXTERP_API_SECRET": "@nexterp_api_secret",
+    "UPLOAD_DIR": "@upload_dir",
+    "MAX_FILE_SIZE": "@max_file_size"
   },
   "build": {
     "env": {

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,10 @@
   "env": {
     "DATABASE_URL": "@database_url",
     "NEXTAUTH_SECRET": "@nextauth_secret",
-    "NEXTAUTH_URL": "@nextauth_url"
+    "NEXTAUTH_URL": "@nextauth_url",
+    "NEXTERP_HOST": "@nexterp_host",
+    "NEXTERP_API_KEY": "@nexterp_api_key",
+    "NEXTERP_API_SECRET": "@nexterp_api_secret"
   },
   "build": {
     "env": {
@@ -20,4 +23,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Adds production-ready Vercel config and smoke test scaffolding.

Changes
- vercel.json: maps Next.js build and environment variables (DATABASE_URL, NEXTAUTH_*, NEXTERP_*).
- /api/health: returns { ok: true } for uptime checks.
- docs/deploy-smoke.md: curl examples for ERPNext-backed routes.
- .github/workflows/vercel-preview.yml: PR build to catch regressions (no secrets used).
- README: concise deploy instructions for Vercel, including env vars.

Verification
- Local: npm install && npm run build succeeds.
- Dev server boots and routes respond; ERPNext routes require NEXTERP_* at runtime.

Next steps
- In Vercel dashboard, add env vars for Production/Preview:
  - DATABASE_URL, NEXTAUTH_URL, NEXTAUTH_SECRET
  - NEXTERP_HOST, NEXTERP_API_KEY, NEXTERP_API_SECRET
- Deploy and run docs/deploy-smoke.md checks.