### PR TITLE
chore(vercel): minimal config to use Next.js defaults

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,21 +1,3 @@
 {
-  "framework": "nextjs",
-  "buildCommand": "npm run build",
-  "outputDirectory": ".next",
-  "installCommand": "npm install",
-  "devCommand": "npm run dev",
-  "env": {
-    "NEXTAUTH_SECRET": "@nextauth_secret",
-    "NEXTAUTH_URL": "@nextauth_url",
-    "NEXTERP_HOST": "@nexterp_host",
-    "NEXTERP_API_KEY": "@nexterp_api_key",
-    "NEXTERP_API_SECRET": "@nexterp_api_secret",
-    "UPLOAD_DIR": "@upload_dir",
-    "MAX_FILE_SIZE": "@max_file_size"
-  },
-  "functions": {
-    "app/api/**/*.ts": {
-      "maxDuration": 30
-    }
-  }
+  "version": 2
 }


### PR DESCRIPTION
Simplifies vercel.json to only { "version": 2 } so Vercel uses standard Next.js build settings. This often resolves stalled deployments when custom commands/env mapping conflict with Project settings. DATABASE_URL and other envs remain configured via Vercel Project settings/secrets.