### PR TITLE
chore: prisma generate on postinstall (Vercel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "postinstall": "prisma generate",
     "lint": "next lint",
     "test": "npm run test:unit && npm run test:e2e",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Adds postinstall script to run 'prisma generate' so Prisma Client is up-to-date in Vercel builds per https://pris.ly/d/vercel-build.